### PR TITLE
Web Rendering of Bold Math Symbols Broken with MathJax

### DIFF
--- a/vignettes-raw/glmm_factor.Rmd
+++ b/vignettes-raw/glmm_factor.Rmd
@@ -41,13 +41,13 @@ head(IRTsim)
 Each student is identified by a student id `sid`, and each school with a school id given by the `school` variable. For each student, five item measurements have been made. We assume that the student's performance depends both on the students ability as well as on the school the student attends. Having the outline of GALAMMs from the [introductory vignette](https://docs.ropensci.org/galamm/articles/galamm.html) in mind, we assume a binomial response model with a logit link, yielding for the $i$th measurement of the $j$th student in the $k$th school,
 
 $$
-\text{P}(y_{ijk} = 1 | \mathbf{x}_{ijk}, \boldsymbol{\eta}_{jk}) = \frac{\exp(\nu_{ijk})}{1 + \exp(\nu_{ijk})}
+\text{P}(y_{ijk} = 1 | \mathbf{x}_{ijk}, \pmb{\eta}_{jk}) = \frac{\exp(\nu_{ijk})}{1 + \exp(\nu_{ijk})}
 $$
 
-The latent variable vector is given by $\boldsymbol{\eta}_{jk} = (\eta_{j}, \eta_{jk})^{T}$, where the last element is the effect of the school which the $j$th student attends. The nonlinear predictor is given by
+The latent variable vector is given by $\pmb{\eta}_{jk} = (\eta_{j}, \eta_{jk})^{T}$, where the last element is the effect of the school which the $j$th student attends. The nonlinear predictor is given by
 
 $$
-\nu_{ijk} = \mathbf{x}_{ijk}^{T} \boldsymbol{\beta} + \mathbf{x}_{ijk}^{T}\boldsymbol{\lambda} (\eta_{j} + \eta_{jk})
+\nu_{ijk} = \mathbf{x}_{ijk}^{T} \pmb{\beta} + \mathbf{x}_{ijk}^{T}\pmb{\lambda} (\eta_{j} + \eta_{jk})
 $$
 
 where $\mathbf{x}_{ij}$ is a vector containing dummy variables for items, $\eta_{j}$ is a latent variable describing the underlying ability of student $j$, and $\eta_{k}$ is a latent variable describing the effect of school $k$. The factor loading $\lambda$ describes how the sum of the two latent variables impacts the nonlinear predictor, and hence the probability of correct response. We note that using a common $\lambda$ for two latent variables like this is not necessarily a good model, but it makes this introductory example easier to follow. We will extend the model later.
@@ -55,22 +55,22 @@ where $\mathbf{x}_{ij}$ is a vector containing dummy variables for items, $\eta_
 The structural model is simply
 
 $$
-\boldsymbol{\eta}_{jk} = \boldsymbol{\zeta}_{jk} \sim N_{2}(\mathbf{0}, \boldsymbol{\Psi}),
+\pmb{\eta}_{jk} = \pmb{\zeta}_{jk} \sim N_{2}(\mathbf{0}, \pmb{\Psi}),
 $$
 
-where $N(\mathbf{0}, \boldsymbol{\Psi})$ denotes a bivariate normal distribution with mean zero covariance matrix $\boldsymbol{\Psi}$. The covariance matrix is assumed to be diagonal.
+where $N(\mathbf{0}, \pmb{\Psi})$ denotes a bivariate normal distribution with mean zero covariance matrix $\pmb{\Psi}$. The covariance matrix is assumed to be diagonal.
 
 ```{r}
 IRTsim$item <- factor(IRTsim$item)
 ```
 
-We confirm that `item` has five levels. This means that $\boldsymbol{\lambda}$ is a vector with five elements.
+We confirm that `item` has five levels. This means that $\pmb{\lambda}$ is a vector with five elements.
 
 ```{r}
 table(IRTsim$item)
 ```
 
-For identifiability, we fix the first element of $\boldsymbol{\lambda}$ to one. The rest will be freely estimated. We do this by defining the following matrix. Any numeric value implies that the element is fixed, whereas `NA` implies that the element is unknown, and will be estimated.
+For identifiability, we fix the first element of $\pmb{\lambda}$ to one. The rest will be freely estimated. We do this by defining the following matrix. Any numeric value implies that the element is fixed, whereas `NA` implies that the element is unknown, and will be estimated.
 
 ```{r}
 (loading_matrix <- matrix(c(1, NA, NA, NA, NA), ncol = 1))
@@ -89,7 +89,7 @@ mod <- galamm(
 )
 ```
 
-A couple of things in the model formula are worth pointing out. First the part `(0 + ability | school / sid)` in the model formula specifies that student ability varies between students within schools. It corresponds to the term $\mathbf{x}_{ijk}^{T}\boldsymbol{\lambda} (\eta_{j} + \eta_{jk})$ in the mathematical specification of the model. The variable `ability` is not part of the `IRTsim` dataframe, but is instead specified in the argument `factor = "ability"`. The argument `load_var = "item"` specifies that all rows in the dataframe with the same value of "item" should get the same element of $\boldsymbol{\lambda}$, and hence it defines the dummy variable $\mathbf{x}_{ijk}$. Finally, `lambda = loading_matrix` provides the matrix of factor loadings. Note that we must explicitly add a zero in `(0 + ability | school / sid)` to avoid having a random intercept estimated in addition to the effect for each value of "item"; such a model would not be identified. The fixed effect part of the model formula, which is simply `item`, specifies the term $\mathbf{x}_{ijk}^{T} \boldsymbol{\beta}$.
+A couple of things in the model formula are worth pointing out. First the part `(0 + ability | school / sid)` in the model formula specifies that student ability varies between students within schools. It corresponds to the term $\mathbf{x}_{ijk}^{T}\pmb{\lambda} (\eta_{j} + \eta_{jk})$ in the mathematical specification of the model. The variable `ability` is not part of the `IRTsim` dataframe, but is instead specified in the argument `factor = "ability"`. The argument `load_var = "item"` specifies that all rows in the dataframe with the same value of "item" should get the same element of $\pmb{\lambda}$, and hence it defines the dummy variable $\mathbf{x}_{ijk}$. Finally, `lambda = loading_matrix` provides the matrix of factor loadings. Note that we must explicitly add a zero in `(0 + ability | school / sid)` to avoid having a random intercept estimated in addition to the effect for each value of "item"; such a model would not be identified. The fixed effect part of the model formula, which is simply `item`, specifies the term $\mathbf{x}_{ijk}^{T} \pmb{\beta}$.
 
 We can start by inspecting the fitted model:
 

--- a/vignettes-raw/latent_observed_interaction.Rmd
+++ b/vignettes-raw/latent_observed_interaction.Rmd
@@ -46,7 +46,7 @@ y_{2} \\
 y_{3}
 \end{pmatrix}
 =
-\boldsymbol{\beta}_{0} +
+\pmb{\beta}_{0} +
 \begin{pmatrix}
 1 & 0 & 0 & 0 \\
 0 & 1 & 0 & 0 \\
@@ -65,10 +65,10 @@ y_{3}
 0 \\
 x \beta
 \end{pmatrix}
-+ \boldsymbol{\epsilon}.
++ \pmb{\epsilon}.
 $$
 
-In this equation $\boldsymbol{\beta}_{0} \in \mathbb{R}^{3}$ is a vector of intercepts, $\eta$ is a latent variable, the loading of the latent variable onto the first measurement $y_{1}$ is fixed to 1 for identifiability, $\lambda_{2}$ is the loading of the latent variable onto the second measurement $y_{2}$, $\lambda_{3}$ is the main effect of the latent variable on the response of interest $y_{3}$, $\beta$ is the effect of the observed covariate $x$ on $y_{3}$, and $\lambda_{4}$ is the interaction effect of $x$ and $\eta$ on $y_{3}$. We assume that the residuals $\boldsymbol{\epsilon}$ are independently and identically normally distributed; this assumption is valid in this simulated case, but note that since the response $y_{3}$ is qualitatively different from the measurements $y_{1}$ and $y_{2}$, this assumption will in general not hold, and a [heteroscedastic measurement model](https://docs.ropensci.org/galamm/articles/lmm_heteroscedastic.html) should be used, or a [model with mixed response types](https://docs.ropensci.org/galamm/articles/mixed_response.html). For a more detailed explanation of this way of formulating latent variable models in matrix form we refer to the first four pages of @rockwoodEstimatingComplexMeasurement2019.
+In this equation $\pmb{\beta}_{0} \in \mathbb{R}^{3}$ is a vector of intercepts, $\eta$ is a latent variable, the loading of the latent variable onto the first measurement $y_{1}$ is fixed to 1 for identifiability, $\lambda_{2}$ is the loading of the latent variable onto the second measurement $y_{2}$, $\lambda_{3}$ is the main effect of the latent variable on the response of interest $y_{3}$, $\beta$ is the effect of the observed covariate $x$ on $y_{3}$, and $\lambda_{4}$ is the interaction effect of $x$ and $\eta$ on $y_{3}$. We assume that the residuals $\pmb{\epsilon}$ are independently and identically normally distributed; this assumption is valid in this simulated case, but note that since the response $y_{3}$ is qualitatively different from the measurements $y_{1}$ and $y_{2}$, this assumption will in general not hold, and a [heteroscedastic measurement model](https://docs.ropensci.org/galamm/articles/lmm_heteroscedastic.html) should be used, or a [model with mixed response types](https://docs.ropensci.org/galamm/articles/mixed_response.html). For a more detailed explanation of this way of formulating latent variable models in matrix form we refer to the first four pages of @rockwoodEstimatingComplexMeasurement2019.
 
 The structural model is simply $\eta = \zeta \sim N(0, \psi)$, where $\psi$ is its variance.
 
@@ -106,7 +106,7 @@ y_{2} \\
 y_{3}
 \end{pmatrix}
 =
-\boldsymbol{\beta}_{0} +
+\pmb{\beta}_{0} +
 \begin{pmatrix}
 1 \\
 \lambda_{2} \\
@@ -119,7 +119,7 @@ y_{3}
 0 \\
 x \beta
 \end{pmatrix}
-+ \boldsymbol{\epsilon}.
++ \pmb{\epsilon}.
 $$
 
 This way of writing shows more explicitly which factor loadings are connected with which observation. In order to fit this model with `galamm`, we must provide formulas for the terms in the loading matrix

--- a/vignettes-raw/lmm_factor.Rmd
+++ b/vignettes-raw/lmm_factor.Rmd
@@ -51,10 +51,10 @@ levels(KYPSsim$time)
 Since students attending a given middle school not necessarily attend the same high school, we have a model with crossed random effects. We use the model of @jeonProfileLikelihoodApproachEstimating2012, whose measurement part can be formulated as
 
 $$
-y_{tsmh} = \beta_{0} + \sum_{t'=2}^{4} d_{tt'}\beta_{t'} + \mathbf{d}_{t}^{T} \left(\boldsymbol{\lambda}_{m}  \eta_{m} + \boldsymbol{\lambda}_{h}  \eta_{h}\right) + \eta_{s} + \epsilon_{tsmh},
+y_{tsmh} = \beta_{0} + \sum_{t'=2}^{4} d_{tt'}\beta_{t'} + \mathbf{d}_{t}^{T} \left(\pmb{\lambda}_{m}  \eta_{m} + \pmb{\lambda}_{h}  \eta_{h}\right) + \eta_{s} + \epsilon_{tsmh},
 $$
 
-where $\mathbf{d}_{t} = (d_{t1},d_{t2},d_{t3},d_{t4})^{T}$ is a vector whose $t$th element equals one and all other elements equal zero. $\beta_{0}$ is an intercept, and $\beta_{2}$, $\beta_{3}$, and $\beta_{4}$ are the effects of timepoints 2, 3, and 4. $\eta_{m}$ and $\eta_{h}$ are the "teacher effects" of middle school $m$ and high school $s$, respectively, $\eta_{s}$ is the latent level for student $s$, and $\epsilon_{tsmh}$ is a residual term. $\boldsymbol{\lambda}_{m}$ and $\boldsymbol{\lambda}_{h}$ are factor loadings (called "persistence parameters" by @mccaffreyModelsValueAddedModeling2004 and @jeonProfileLikelihoodApproachEstimating2012) specifying how the teacher effects for middle school and high school impact the self esteem measurement. Since students attend high school after middle school, the measurements of self esteem in middle school are assumed not to be affected by high school, and hence the first two elements of $\boldsymbol{\lambda}_{h}$ are set to zero. The first nonzero element is set to zero for identifiability, so we have $\boldsymbol{\lambda}_{h} = (0, 0, 1, \lambda_{h4})^{T}$. Conversely, we allow for middle school to have an effect of measurements in high school, so $\boldsymbol{\lambda}_{m} = (1, \lambda_{m2}, \lambda_{m3}, \lambda_{m4})^{T}$, with the first element set to zero for identifiability. The residuals are assumed normally distributed, $\epsilon_{tsmh} \sim N(0, \phi)$.
+where $\mathbf{d}_{t} = (d_{t1},d_{t2},d_{t3},d_{t4})^{T}$ is a vector whose $t$th element equals one and all other elements equal zero. $\beta_{0}$ is an intercept, and $\beta_{2}$, $\beta_{3}$, and $\beta_{4}$ are the effects of timepoints 2, 3, and 4. $\eta_{m}$ and $\eta_{h}$ are the "teacher effects" of middle school $m$ and high school $s$, respectively, $\eta_{s}$ is the latent level for student $s$, and $\epsilon_{tsmh}$ is a residual term. $\pmb{\lambda}_{m}$ and $\pmb{\lambda}_{h}$ are factor loadings (called "persistence parameters" by @mccaffreyModelsValueAddedModeling2004 and @jeonProfileLikelihoodApproachEstimating2012) specifying how the teacher effects for middle school and high school impact the self esteem measurement. Since students attend high school after middle school, the measurements of self esteem in middle school are assumed not to be affected by high school, and hence the first two elements of $\pmb{\lambda}_{h}$ are set to zero. The first nonzero element is set to zero for identifiability, so we have $\pmb{\lambda}_{h} = (0, 0, 1, \lambda_{h4})^{T}$. Conversely, we allow for middle school to have an effect of measurements in high school, so $\pmb{\lambda}_{m} = (1, \lambda_{m2}, \lambda_{m3}, \lambda_{m4})^{T}$, with the first element set to zero for identifiability. The residuals are assumed normally distributed, $\epsilon_{tsmh} \sim N(0, \phi)$.
 
 Written out for each of the four timepoints, the model becomes
 
@@ -93,7 +93,7 @@ $$
 
 where $N_{3}(a, b)$ denotes a trivariate normal distribution with mean $a$ and covariance $b$.
 
-In order to fit the model with galamm, we use syntax similar to PLmixed, and start by defining the loading matrix. The first column contains $\boldsymbol{\lambda}_{m}$ and the second column contains $\boldsymbol{\lambda}_{h}$. Numerical values in this matrix means that the entry is fixed to the given value, whereas `NA` means that the value is unknown, and should be estimated.
+In order to fit the model with galamm, we use syntax similar to PLmixed, and start by defining the loading matrix. The first column contains $\pmb{\lambda}_{m}$ and the second column contains $\pmb{\lambda}_{h}$. Numerical values in this matrix means that the entry is fixed to the given value, whereas `NA` means that the value is unknown, and should be estimated.
 
 
 ```{r}
@@ -170,7 +170,7 @@ A diagnostic plot of residuals versus predicted values also looks acceptable, al
 plot(mod, abline = c(0, 0))
 ```
 
-We can also compare the estimated model to a model with constrained factor loadings. In particular, we could assume that the teacher effect in middle school has no effect on self esteem measured during high school, by setting the last two elements of $\boldsymbol{\lambda}_{m}$ to zero. We would then have the following loading matrix.
+We can also compare the estimated model to a model with constrained factor loadings. In particular, we could assume that the teacher effect in middle school has no effect on self esteem measured during high school, by setting the last two elements of $\pmb{\lambda}_{m}$ to zero. We would then have the following loading matrix.
 
 ```{r}
 (loading_matrix_constr1 <- rbind(
@@ -303,7 +303,7 @@ y_{12tsc} \\
 \eta_{6s}^{(s)} \\
 \eta_{7c}^{(c)} \\
 \end{pmatrix} +
-\boldsymbol{\epsilon}_{tsc}
+\pmb{\epsilon}_{tsc}
 $$
 
 In brief, $\eta_{1t}^{(t)}$ and $\eta_{2t}^{(t)}$ are the teacher effects, $\eta_{3s}^{(s)}$ and $\eta_{4s}^{(s)}$ are teacher's perception of the students on the trait, $\eta_{5s}^{(s)}$ and $\eta_{6s}^{(s)}$ are the students' perception of themselves on the trait, and $\eta_{7c}^{(c)}$ is the classroom effect. The factor loadings are the "regression coefficients" for regressing the observed items onto these latent traits. The subscripts $t$, $s$, and $c$ indicate teacher, student, and class, respectively.
@@ -339,7 +339,7 @@ $$
 \zeta_{1t}^{(t)} \\
 \zeta_{2t}^{(t)} \\
 \end{pmatrix}
-\sim N_{2}(\mathbf{0}, \boldsymbol{\Psi}^{(t)}),
+\sim N_{2}(\mathbf{0}, \pmb{\Psi}^{(t)}),
 $$
 
 $$
@@ -349,7 +349,7 @@ $$
 \zeta_{5s}^{(s)} \\
 \zeta_{6s}^{(s)} \\
 \end{pmatrix}
-\sim N_{4}(\mathbf{0}, \boldsymbol{\Psi}^{(s)}),
+\sim N_{4}(\mathbf{0}, \pmb{\Psi}^{(s)}),
 $$
 
 $$

--- a/vignettes-raw/lmm_heteroscedastic.Rmd
+++ b/vignettes-raw/lmm_heteroscedastic.Rmd
@@ -28,7 +28,7 @@ library(galamm)
 At the moment, galamm supports group-wise heteroscedasticity in Gaussian response models. Referring to the model formulation outlined in the [introductory vignette](https://docs.ropensci.org/galamm/articles/galamm.html), the response model and nonlinear predictor can be easily combined in this particular case, to give
 
 $$
-y_{i} = \sum_{s=1}^{S} f_{s}\left(\mathbf{x}_{i}\right) + \sum_{l=2}^{L}\sum_{m=1}^{M_{l}} \eta_{m}^{(l)} \mathbf{z}^{(l)}_{im}{}^{'}\boldsymbol{\lambda}_{m}^{(l)} + \epsilon_{g(i)},
+y_{i} = \sum_{s=1}^{S} f_{s}\left(\mathbf{x}_{i}\right) + \sum_{l=2}^{L}\sum_{m=1}^{M_{l}} \eta_{m}^{(l)} \mathbf{z}^{(l)}_{im}{}^{'}\pmb{\lambda}_{m}^{(l)} + \epsilon_{g(i)},
 $$
 
 where subscript $i$ refers to the $i$th elementary unit of observation, i.e., the $i$th row in the dataframe. $g(i)$ refers to the group to which the $i$th observation belongs, with each grouping having a separately estimated residual variance, $\epsilon_{g} \sim N(0, \sigma_{g}^{2})$.

--- a/vignettes-raw/mixed_response.Rmd
+++ b/vignettes-raw/mixed_response.Rmd
@@ -46,9 +46,9 @@ for the $i$th observation of the $j$ subject. Although we don't show this with a
 
 Next, the nonlinear predictor is given by
 
-$$\nu_{ij} = \beta_{0} + x_{ij}\beta_{1} + \mathbf{z}_{ij}^{T}\boldsymbol{\lambda} \eta$$
+$$\nu_{ij} = \beta_{0} + x_{ij}\beta_{1} + \mathbf{z}_{ij}^{T}\pmb{\lambda} \eta$$
 
-where $x_{ij}$ is an explanatory and $\mathbf{z}_{ij}$ is a dummy vector of length 2 with exactly one element equal to one and one element equal to zero. When `itemgroup = "a"`, $\mathbf{z} = (1, 0)^{T}$ and when `itemgroup = "b"`, $\mathbf{z} = (0, 1)^{T}$. The parameter $\boldsymbol{\lambda} = (1, \lambda)^{T}$ is a vector of factor loadings, whose first element equals zero for identifiability. $\eta$ is a latent variable, in this case representing an underlying trait "causing" the observed responses.
+where $x_{ij}$ is an explanatory and $\mathbf{z}_{ij}$ is a dummy vector of length 2 with exactly one element equal to one and one element equal to zero. When `itemgroup = "a"`, $\mathbf{z} = (1, 0)^{T}$ and when `itemgroup = "b"`, $\mathbf{z} = (0, 1)^{T}$. The parameter $\pmb{\lambda} = (1, \lambda)^{T}$ is a vector of factor loadings, whose first element equals zero for identifiability. $\eta$ is a latent variable, in this case representing an underlying trait "causing" the observed responses.
 
 The structural model is simply
 
@@ -58,7 +58,7 @@ $$
 
 where $N(0, \psi)$ denotes a normal distribution with mean 0 and variance $\psi$.
 
-We define the loading matrix as follows, where the value `1` indicates that the first element $\boldsymbol{\lambda}$ is fixed, and the value `NA` indicates that its second element is unknown, and to be estimated.
+We define the loading matrix as follows, where the value `1` indicates that the first element $\pmb{\lambda}$ is fixed, and the value `NA` indicates that its second element is unknown, and to be estimated.
 
 ```{r}
 (loading_matrix <- matrix(c(1, NA), ncol = 1))
@@ -148,7 +148,7 @@ diet[diet$id %in% c(219, 220, 221), ]
 
 Our first goal is to model the effect of fiber intake on risk of heart disease. Since this variable is very likely to be subject to measurement error, it is well known that simply averaging the two measurements, where available, and using the single measurement otherwise, will lead to bias and lack of power [@carrollMeasurementErrorNonlinear2006]. Instead, we let $\eta_{j}$ denote the true (latent) fiber intake of person $j$, and define the structural model
 
-$$\eta_{j} = \mathbf{x}_{ij}'\boldsymbol{\gamma} + \zeta_{j}.$$
+$$\eta_{j} = \mathbf{x}_{ij}'\pmb{\gamma} + \zeta_{j}.$$
 
 where $\mathbf{x}_{ij}$ is a vector of covariates age, bus, and their interaction, as well as a constant term for defining the intercept. The R formula for setting up the model matrix would be `model.matrix(~ age * bus, data = diet)`. The term $\zeta_{j}$ is a normally distributed disturbance, $\zeta_{j} \sim N(0, \psi)$.
 
@@ -162,16 +162,16 @@ $$y_{ij} = d_{2ij} \beta_{0} + \eta_{j} + \epsilon_{ij}, \qquad \epsilon_{ij} = 
 
 Next, for the rows corresponding to coronary heart disease measurement, we assume a binomial model with a logit link function, i.e., logistic regression. This model is given by
 
-$$\text{logit}[P(y_{ij}=1 | \eta_{j})] = \mathbf{x}_{ij}'\boldsymbol{\beta} + \lambda \eta_{j},$$
+$$\text{logit}[P(y_{ij}=1 | \eta_{j})] = \mathbf{x}_{ij}'\pmb{\beta} + \lambda \eta_{j},$$
 
-where $\mathbf{x}_{ij}$ is the same as before, but where $\boldsymbol{\beta}$ now represents the direct effect of age and bus on the probability of coronary heart disease. The factor loading $\lambda$ is the regression coefficient for latent fiber intake on the risk of coronary heart disease.
+where $\mathbf{x}_{ij}$ is the same as before, but where $\pmb{\beta}$ now represents the direct effect of age and bus on the probability of coronary heart disease. The factor loading $\lambda$ is the regression coefficient for latent fiber intake on the risk of coronary heart disease.
 
 
 ### Nonlinear Predictor
 
 Stacking the three responses, which are fiber intake at times 1 and 2, and coronary heart disease, we can define the joint model as a GLLAMM with nonlinear predictor
 
-$$\nu_{ij} = d_{2ij} \beta_{0} + d_{3ij} \mathbf{x}_{j}'\boldsymbol{\beta} + \mathbf{x}_{j}'\boldsymbol{\gamma}\left[(d_{1i} + d_{2i}) + \lambda d_{3i}\right] + \zeta_{j} \left[(d_{1i} + d_{2i}) + \lambda d_{3i}\right],$$
+$$\nu_{ij} = d_{2ij} \beta_{0} + d_{3ij} \mathbf{x}_{j}'\pmb{\beta} + \mathbf{x}_{j}'\pmb{\gamma}\left[(d_{1i} + d_{2i}) + \lambda d_{3i}\right] + \zeta_{j} \left[(d_{1i} + d_{2i}) + \lambda d_{3i}\right],$$
 
 where $d_{1i}$ is a dummy variable for fiber measurements at timepoint 1 and $d_{3i}$ is an indicator for coronary heart disease.
 
@@ -209,7 +209,7 @@ formula <- y ~ 0 + chd + (age * bus):chd + fiber +
   (age * bus):fiber + fiber2 + (0 + loading | id)
 ```
 
-The initial zero specifies that we don't want R to insert an intercept term. Next, `chd + (age * bus) : chd` applies to "chd" rows only, and corresponds to $\mathbf{x}_{ij}^{T} \boldsymbol{\beta}$ in the disease model. The part `fiber + (age * bus) : fiber` corresponds to the term $\mathbf{x}_{ij}^{T}\boldsymbol{\gamma}$ in the disease model, and `fiber2` corresponds to the drift term $d_{2ij}\beta_{0}$.
+The initial zero specifies that we don't want R to insert an intercept term. Next, `chd + (age * bus) : chd` applies to "chd" rows only, and corresponds to $\mathbf{x}_{ij}^{T} \pmb{\beta}$ in the disease model. The part `fiber + (age * bus) : fiber` corresponds to the term $\mathbf{x}_{ij}^{T}\pmb{\gamma}$ in the disease model, and `fiber2` corresponds to the drift term $d_{2ij}\beta_{0}$.
 
 We can inspect the model implied by the formula by using the `nobars` function from [lme4](https://cran.r-project.org/package=lme4) [@batesFittingLinearMixedEffects2015] to remove the random effects, and then `model.matrix`. It looks correctly set up.
 

--- a/vignettes/galamm.Rmd
+++ b/vignettes/galamm.Rmd
@@ -50,16 +50,16 @@ $$
 Next, the nonlinear predictor, which corresponds to the measurement model in a classical structural equation model, is defined by
 
 $$
-\nu = \sum_{s=1}^{S} f_{s}\left(\mathbf{x}\right) + \sum_{l=2}^{L}\sum_{m=1}^{M_{l}} \eta_{m}^{(l)} \mathbf{z}^{(l)}_{m}{}^{'}\boldsymbol{\lambda}_{m}^{(l)},
+\nu = \sum_{s=1}^{S} f_{s}\left(\mathbf{x}\right) + \sum_{l=2}^{L}\sum_{m=1}^{M_{l}} \eta_{m}^{(l)} \mathbf{z}^{(l)}_{m}{}^{'}\pmb{\lambda}_{m}^{(l)},
 $$
 
-where $\mathbf{x}$ are explanatory variables, $f_{s}(\mathbf{x})$, $s=1,\dots,S$ are smooth functions, $\eta_{m}^{(l)}$ are latent variables varying at level $l$, and $\boldsymbol{\lambda}_{m}^{(l)}{}^{T} \mathbf{z}_{m}^{(l)}$ is the weighted sum of a vector of explanatory variables $\mathbf{z}_{m}^{(l)}$ varying at level $l$ and parameters $\boldsymbol{\lambda}_{m}^{(l)}$. Let
+where $\mathbf{x}$ are explanatory variables, $f_{s}(\mathbf{x})$, $s=1,\dots,S$ are smooth functions, $\eta_{m}^{(l)}$ are latent variables varying at level $l$, and $\pmb{\lambda}_{m}^{(l)}{}^{T} \mathbf{z}_{m}^{(l)}$ is the weighted sum of a vector of explanatory variables $\mathbf{z}_{m}^{(l)}$ varying at level $l$ and parameters $\pmb{\lambda}_{m}^{(l)}$. Let
 
-$$\boldsymbol{\eta}^{(l)} = [\eta_{1}^{(l)}, \dots, \eta_{M_{l}}^{(l)}]^{T} \in \mathbb{R}^{M_{l}}$$ 
+$$\pmb{\eta}^{(l)} = [\eta_{1}^{(l)}, \dots, \eta_{M_{l}}^{(l)}]^{T} \in \mathbb{R}^{M_{l}}$$ 
 
 be the vector of all latent variables at level $l$, and 
 
-$$\boldsymbol{\eta} = [\boldsymbol{\eta}^{(2)}, \dots, \boldsymbol{\eta}^{(L)}]^{T} \in \mathbb{R}^{M}$$ 
+$$\pmb{\eta} = [\pmb{\eta}^{(2)}, \dots, \pmb{\eta}^{(L)}]^{T} \in \mathbb{R}^{M}$$ 
 
 the vector of all latent variables belonging to a given level-2 unit, where $M = \sum_{l=2}^{L} M_{l}$. The word "level" is here used to denote a grouping level; they are not necessarily hierarchical.
 
@@ -68,12 +68,12 @@ the vector of all latent variables belonging to a given level-2 unit, where $M =
 The structural model specifies how the latent variables are related to each other and to observed variables, and is given by
 
 $$
-\boldsymbol{\eta} = \mathbf{B}\boldsymbol{\eta} + \mathbf{h}\left(\mathbf{w}\right)
-+ \boldsymbol{\zeta}
+\pmb{\eta} = \mathbf{B}\pmb{\eta} + \mathbf{h}\left(\mathbf{w}\right)
++ \pmb{\zeta}
 $$
 
 
-where $\mathbf{B}$ is an $M \times M$ matrix of regression coefficients for regression among latent variables and $\mathbf{w} \in \mathbb{R}^{Q}$ is a vector of $Q$ predictors for the latent variables. $\mathbf{h}(\mathbf{w}) = [\mathbf{h}_{2}(\mathbf{w}), \dots, \mathbf{h}_{L}(\mathbf{w})] \in \mathbb{R}^{M}$ is a vector of smooth functions whose components $\mathbf{h}_{l}(\mathbf{w}) \in \mathbb{R}^{M_{l}}$ are vectors of functions predicting the latent variables varying at level $l$, and depending on a subset of the elements $\mathbf{w}$. $\boldsymbol{\zeta}$ is a vector of normally distributed random effects, $\boldsymbol{\zeta}^{(l)} \sim N(\mathbf{0}, \boldsymbol{\Psi}^{(l)})$ for $l=2,\dots,L$, where $\boldsymbol{\Psi}^{(l)} \in \mathbb{R}^{M_{l} \times M_{l}}$ is the covariance matrix of random effects at level $l$. Defining the $M \times M$ covariance matrix $\boldsymbol{\Psi} = \text{diag}(\boldsymbol{\Psi}^{(2)}, \dots, \boldsymbol{\Psi}^{(L)})$, we also have $\boldsymbol{\zeta} \sim N(\mathbf{0}, \boldsymbol{\Psi})$. 
+where $\mathbf{B}$ is an $M \times M$ matrix of regression coefficients for regression among latent variables and $\mathbf{w} \in \mathbb{R}^{Q}$ is a vector of $Q$ predictors for the latent variables. $\mathbf{h}(\mathbf{w}) = [\mathbf{h}_{2}(\mathbf{w}), \dots, \mathbf{h}_{L}(\mathbf{w})] \in \mathbb{R}^{M}$ is a vector of smooth functions whose components $\mathbf{h}_{l}(\mathbf{w}) \in \mathbb{R}^{M_{l}}$ are vectors of functions predicting the latent variables varying at level $l$, and depending on a subset of the elements $\mathbf{w}$. $\pmb{\zeta}$ is a vector of normally distributed random effects, $\pmb{\zeta}^{(l)} \sim N(\mathbf{0}, \pmb{\Psi}^{(l)})$ for $l=2,\dots,L$, where $\pmb{\Psi}^{(l)} \in \mathbb{R}^{M_{l} \times M_{l}}$ is the covariance matrix of random effects at level $l$. Defining the $M \times M$ covariance matrix $\pmb{\Psi} = \text{diag}(\pmb{\Psi}^{(2)}, \dots, \pmb{\Psi}^{(L)})$, we also have $\pmb{\zeta} \sim N(\mathbf{0}, \pmb{\Psi})$. 
 
 ## Mixed Model Representation
 
@@ -90,24 +90,24 @@ In galamm we use the same transformations as the [gamm4](https://CRAN.R-project.
 In mixed model representation, the nonlinear predictor can be written on the form
 
 $$
-\boldsymbol{\nu} = \mathbf{X}(\boldsymbol{\lambda}, \mathbf{B}) \boldsymbol{\beta} +  \mathbf{Z}(\boldsymbol{\lambda}, \mathbf{B}) \boldsymbol{\zeta}
+\pmb{\nu} = \mathbf{X}(\pmb{\lambda}, \mathbf{B}) \pmb{\beta} +  \mathbf{Z}(\pmb{\lambda}, \mathbf{B}) \pmb{\zeta}
 $$
 
-where $\mathbf{X}(\boldsymbol{\lambda}, \mathbf{B})$ is the regression matrix for fixed effects $\boldsymbol{\beta}$ and $\mathbf{Z}(\boldsymbol{\lambda}, \mathbf{B})$ is the regression matrix for random effects $\boldsymbol{\zeta}$. In contrast to with generalized linear mixed models, however, both matrices will in general depend on factor loadings $\boldsymbol{\lambda}$ and regression coefficients between latent variables $\mathbf{B}$. Both of these are parameters that need to be estimated, and hence $\mathbf{X}(\boldsymbol{\lambda}, \mathbf{B})$ and $\boldsymbol{\beta}$ and $\mathbf{Z}(\boldsymbol{\lambda}, \mathbf{B})$ need to be updated throughout the estimation process.
+where $\mathbf{X}(\pmb{\lambda}, \mathbf{B})$ is the regression matrix for fixed effects $\pmb{\beta}$ and $\mathbf{Z}(\pmb{\lambda}, \mathbf{B})$ is the regression matrix for random effects $\pmb{\zeta}$. In contrast to with generalized linear mixed models, however, both matrices will in general depend on factor loadings $\pmb{\lambda}$ and regression coefficients between latent variables $\mathbf{B}$. Both of these are parameters that need to be estimated, and hence $\mathbf{X}(\pmb{\lambda}, \mathbf{B})$ and $\pmb{\beta}$ and $\mathbf{Z}(\pmb{\lambda}, \mathbf{B})$ need to be updated throughout the estimation process.
 
 ### Evaluating the Marginal Likelihood
 
 Plugging the nonlinear predictor into the structural model, we obtain the joint likelihood for the model. We then obtain the marginal likelihood by integrating over the random effects, yielding a marginal likelihood function of the form
 
 $$
-L\left(\boldsymbol{\beta}, \boldsymbol{\Lambda}, \boldsymbol{\Gamma}, \boldsymbol{\lambda}, \mathbf{B}, \boldsymbol{\phi}\right) =  \left(2 \pi \phi_{1}\right)^{-r/2}  \int_{\mathbb{R}^{r}} \exp\left( g\left(\boldsymbol{\beta}, \boldsymbol{\Lambda}, \boldsymbol{\Gamma}, \boldsymbol{\lambda}, \mathbf{B}, \boldsymbol{\phi}, \mathbf{u}\right) \right) \text{d} \mathbf{u}
+L\left(\pmb{\beta}, \pmb{\Lambda}, \pmb{\Gamma}, \pmb{\lambda}, \mathbf{B}, \pmb{\phi}\right) =  \left(2 \pi \phi_{1}\right)^{-r/2}  \int_{\mathbb{R}^{r}} \exp\left( g\left(\pmb{\beta}, \pmb{\Lambda}, \pmb{\Gamma}, \pmb{\lambda}, \mathbf{B}, \pmb{\phi}, \mathbf{u}\right) \right) \text{d} \mathbf{u}
 $$
 
-where $\mathbf{u}$ is a standardized version of $\boldsymbol{\zeta}$. In order to evaluate the marginal likelihood at a given set of parameter values, we use the Laplace approximation combined with sparse matrix operations, extending @batesFittingLinearMixedEffects2015's algorithm for linear mixed models.
+where $\mathbf{u}$ is a standardized version of $\pmb{\zeta}$. In order to evaluate the marginal likelihood at a given set of parameter values, we use the Laplace approximation combined with sparse matrix operations, extending @batesFittingLinearMixedEffects2015's algorithm for linear mixed models.
 
 ### Maximizing the Marginal Likelihood
 
-We obtain maximum marginal likelihood estimates by maximizing $L\left(\boldsymbol{\beta}, \boldsymbol{\Lambda}, \boldsymbol{\Gamma}, \boldsymbol{\lambda}, \mathbf{B}, \boldsymbol{\phi}\right)$, subject to possible constraints, e.g., that variances are non-negative. For this, we use the L-BFGS-B algorithm implement in `stats::optim`. The predicted values of random effects, $\widehat{\mathbf{u}}$ are obtained as posterior modes at the final estimates.
+We obtain maximum marginal likelihood estimates by maximizing $L\left(\pmb{\beta}, \pmb{\Lambda}, \pmb{\Gamma}, \pmb{\lambda}, \mathbf{B}, \pmb{\phi}\right)$, subject to possible constraints, e.g., that variances are non-negative. For this, we use the L-BFGS-B algorithm implement in `stats::optim`. The predicted values of random effects, $\widehat{\mathbf{u}}$ are obtained as posterior modes at the final estimates.
 
 ## Example Models 
 

--- a/vignettes/glmm_factor.Rmd
+++ b/vignettes/glmm_factor.Rmd
@@ -43,13 +43,13 @@ head(IRTsim)
 Each student is identified by a student id `sid`, and each school with a school id given by the `school` variable. For each student, five item measurements have been made. We assume that the student's performance depends both on the students ability as well as on the school the student attends. Having the outline of GALAMMs from the [introductory vignette](https://docs.ropensci.org/galamm/articles/galamm.html) in mind, we assume a binomial response model with a logit link, yielding for the $i$th measurement of the $j$th student in the $k$th school,
 
 $$
-\text{P}(y_{ijk} = 1 | \mathbf{x}_{ijk}, \boldsymbol{\eta}_{jk}) = \frac{\exp(\nu_{ijk})}{1 + \exp(\nu_{ijk})}
+\text{P}(y_{ijk} = 1 | \mathbf{x}_{ijk}, \pmb{\eta}_{jk}) = \frac{\exp(\nu_{ijk})}{1 + \exp(\nu_{ijk})}
 $$
 
-The latent variable vector is given by $\boldsymbol{\eta}_{jk} = (\eta_{j}, \eta_{jk})^{T}$, where the last element is the effect of the school which the $j$th student attends. The nonlinear predictor is given by
+The latent variable vector is given by $\pmb{\eta}_{jk} = (\eta_{j}, \eta_{jk})^{T}$, where the last element is the effect of the school which the $j$th student attends. The nonlinear predictor is given by
 
 $$
-\nu_{ijk} = \mathbf{x}_{ijk}^{T} \boldsymbol{\beta} + \mathbf{x}_{ijk}^{T}\boldsymbol{\lambda} (\eta_{j} + \eta_{jk})
+\nu_{ijk} = \mathbf{x}_{ijk}^{T} \pmb{\beta} + \mathbf{x}_{ijk}^{T}\pmb{\lambda} (\eta_{j} + \eta_{jk})
 $$
 
 where $\mathbf{x}_{ij}$ is a vector containing dummy variables for items, $\eta_{j}$ is a latent variable describing the underlying ability of student $j$, and $\eta_{k}$ is a latent variable describing the effect of school $k$. The factor loading $\lambda$ describes how the sum of the two latent variables impacts the nonlinear predictor, and hence the probability of correct response. We note that using a common $\lambda$ for two latent variables like this is not necessarily a good model, but it makes this introductory example easier to follow. We will extend the model later.
@@ -57,17 +57,17 @@ where $\mathbf{x}_{ij}$ is a vector containing dummy variables for items, $\eta_
 The structural model is simply
 
 $$
-\boldsymbol{\eta}_{jk} = \boldsymbol{\zeta}_{jk} \sim N_{2}(\mathbf{0}, \boldsymbol{\Psi}),
+\pmb{\eta}_{jk} = \pmb{\zeta}_{jk} \sim N_{2}(\mathbf{0}, \pmb{\Psi}),
 $$
 
-where $N(\mathbf{0}, \boldsymbol{\Psi})$ denotes a bivariate normal distribution with mean zero covariance matrix $\boldsymbol{\Psi}$. The covariance matrix is assumed to be diagonal.
+where $N(\mathbf{0}, \pmb{\Psi})$ denotes a bivariate normal distribution with mean zero covariance matrix $\pmb{\Psi}$. The covariance matrix is assumed to be diagonal.
 
 
 ``` r
 IRTsim$item <- factor(IRTsim$item)
 ```
 
-We confirm that `item` has five levels. This means that $\boldsymbol{\lambda}$ is a vector with five elements.
+We confirm that `item` has five levels. This means that $\pmb{\lambda}$ is a vector with five elements.
 
 
 ``` r
@@ -77,7 +77,7 @@ table(IRTsim$item)
 #> 500 500 500 500 500
 ```
 
-For identifiability, we fix the first element of $\boldsymbol{\lambda}$ to one. The rest will be freely estimated. We do this by defining the following matrix. Any numeric value implies that the element is fixed, whereas `NA` implies that the element is unknown, and will be estimated.
+For identifiability, we fix the first element of $\pmb{\lambda}$ to one. The rest will be freely estimated. We do this by defining the following matrix. Any numeric value implies that the element is fixed, whereas `NA` implies that the element is unknown, and will be estimated.
 
 
 ``` r
@@ -104,7 +104,7 @@ mod <- galamm(
 )
 ```
 
-A couple of things in the model formula are worth pointing out. First the part `(0 + ability | school / sid)` in the model formula specifies that student ability varies between students within schools. It corresponds to the term $\mathbf{x}_{ijk}^{T}\boldsymbol{\lambda} (\eta_{j} + \eta_{jk})$ in the mathematical specification of the model. The variable `ability` is not part of the `IRTsim` dataframe, but is instead specified in the argument `factor = "ability"`. The argument `load_var = "item"` specifies that all rows in the dataframe with the same value of "item" should get the same element of $\boldsymbol{\lambda}$, and hence it defines the dummy variable $\mathbf{x}_{ijk}$. Finally, `lambda = loading_matrix` provides the matrix of factor loadings. Note that we must explicitly add a zero in `(0 + ability | school / sid)` to avoid having a random intercept estimated in addition to the effect for each value of "item"; such a model would not be identified. The fixed effect part of the model formula, which is simply `item`, specifies the term $\mathbf{x}_{ijk}^{T} \boldsymbol{\beta}$.
+A couple of things in the model formula are worth pointing out. First the part `(0 + ability | school / sid)` in the model formula specifies that student ability varies between students within schools. It corresponds to the term $\mathbf{x}_{ijk}^{T}\pmb{\lambda} (\eta_{j} + \eta_{jk})$ in the mathematical specification of the model. The variable `ability` is not part of the `IRTsim` dataframe, but is instead specified in the argument `factor = "ability"`. The argument `load_var = "item"` specifies that all rows in the dataframe with the same value of "item" should get the same element of $\pmb{\lambda}$, and hence it defines the dummy variable $\mathbf{x}_{ijk}$. Finally, `lambda = loading_matrix` provides the matrix of factor loadings. Note that we must explicitly add a zero in `(0 + ability | school / sid)` to avoid having a random intercept estimated in addition to the effect for each value of "item"; such a model would not be identified. The fixed effect part of the model formula, which is simply `item`, specifies the term $\mathbf{x}_{ijk}^{T} \pmb{\beta}$.
 
 We can start by inspecting the fitted model:
 

--- a/vignettes/latent_observed_interaction.Rmd
+++ b/vignettes/latent_observed_interaction.Rmd
@@ -48,7 +48,7 @@ y_{2} \\
 y_{3}
 \end{pmatrix}
 =
-\boldsymbol{\beta}_{0} +
+\pmb{\beta}_{0} +
 \begin{pmatrix}
 1 & 0 & 0 & 0 \\
 0 & 1 & 0 & 0 \\
@@ -67,10 +67,10 @@ y_{3}
 0 \\
 x \beta
 \end{pmatrix}
-+ \boldsymbol{\epsilon}.
++ \pmb{\epsilon}.
 $$
 
-In this equation $\boldsymbol{\beta}_{0} \in \mathbb{R}^{3}$ is a vector of intercepts, $\eta$ is a latent variable, the loading of the latent variable onto the first measurement $y_{1}$ is fixed to 1 for identifiability, $\lambda_{2}$ is the loading of the latent variable onto the second measurement $y_{2}$, $\lambda_{3}$ is the main effect of the latent variable on the response of interest $y_{3}$, $\beta$ is the effect of the observed covariate $x$ on $y_{3}$, and $\lambda_{4}$ is the interaction effect of $x$ and $\eta$ on $y_{3}$. We assume that the residuals $\boldsymbol{\epsilon}$ are independently and identically normally distributed; this assumption is valid in this simulated case, but note that since the response $y_{3}$ is qualitatively different from the measurements $y_{1}$ and $y_{2}$, this assumption will in general not hold, and a [heteroscedastic measurement model](https://docs.ropensci.org/galamm/articles/lmm_heteroscedastic.html) should be used, or a [model with mixed response types](https://docs.ropensci.org/galamm/articles/mixed_response.html). For a more detailed explanation of this way of formulating latent variable models in matrix form we refer to the first four pages of @rockwoodEstimatingComplexMeasurement2019.
+In this equation $\pmb{\beta}_{0} \in \mathbb{R}^{3}$ is a vector of intercepts, $\eta$ is a latent variable, the loading of the latent variable onto the first measurement $y_{1}$ is fixed to 1 for identifiability, $\lambda_{2}$ is the loading of the latent variable onto the second measurement $y_{2}$, $\lambda_{3}$ is the main effect of the latent variable on the response of interest $y_{3}$, $\beta$ is the effect of the observed covariate $x$ on $y_{3}$, and $\lambda_{4}$ is the interaction effect of $x$ and $\eta$ on $y_{3}$. We assume that the residuals $\pmb{\epsilon}$ are independently and identically normally distributed; this assumption is valid in this simulated case, but note that since the response $y_{3}$ is qualitatively different from the measurements $y_{1}$ and $y_{2}$, this assumption will in general not hold, and a [heteroscedastic measurement model](https://docs.ropensci.org/galamm/articles/lmm_heteroscedastic.html) should be used, or a [model with mixed response types](https://docs.ropensci.org/galamm/articles/mixed_response.html). For a more detailed explanation of this way of formulating latent variable models in matrix form we refer to the first four pages of @rockwoodEstimatingComplexMeasurement2019.
 
 The structural model is simply $\eta = \zeta \sim N(0, \psi)$, where $\psi$ is its variance.
 
@@ -139,7 +139,7 @@ y_{2} \\
 y_{3}
 \end{pmatrix}
 =
-\boldsymbol{\beta}_{0} +
+\pmb{\beta}_{0} +
 \begin{pmatrix}
 1 \\
 \lambda_{2} \\
@@ -152,7 +152,7 @@ y_{3}
 0 \\
 x \beta
 \end{pmatrix}
-+ \boldsymbol{\epsilon}.
++ \pmb{\epsilon}.
 $$
 
 This way of writing shows more explicitly which factor loadings are connected with which observation. In order to fit this model with `galamm`, we must provide formulas for the terms in the loading matrix

--- a/vignettes/lmm_factor.Rmd
+++ b/vignettes/lmm_factor.Rmd
@@ -55,10 +55,10 @@ levels(KYPSsim$time)
 Since students attending a given middle school not necessarily attend the same high school, we have a model with crossed random effects. We use the model of @jeonProfileLikelihoodApproachEstimating2012, whose measurement part can be formulated as
 
 $$
-y_{tsmh} = \beta_{0} + \sum_{t'=2}^{4} d_{tt'}\beta_{t'} + \mathbf{d}_{t}^{T} \left(\boldsymbol{\lambda}_{m}  \eta_{m} + \boldsymbol{\lambda}_{h}  \eta_{h}\right) + \eta_{s} + \epsilon_{tsmh},
+y_{tsmh} = \beta_{0} + \sum_{t'=2}^{4} d_{tt'}\beta_{t'} + \mathbf{d}_{t}^{T} \left(\pmb{\lambda}_{m}  \eta_{m} + \pmb{\lambda}_{h}  \eta_{h}\right) + \eta_{s} + \epsilon_{tsmh},
 $$
 
-where $\mathbf{d}_{t} = (d_{t1},d_{t2},d_{t3},d_{t4})^{T}$ is a vector whose $t$th element equals one and all other elements equal zero. $\beta_{0}$ is an intercept, and $\beta_{2}$, $\beta_{3}$, and $\beta_{4}$ are the effects of timepoints 2, 3, and 4. $\eta_{m}$ and $\eta_{h}$ are the "teacher effects" of middle school $m$ and high school $s$, respectively, $\eta_{s}$ is the latent level for student $s$, and $\epsilon_{tsmh}$ is a residual term. $\boldsymbol{\lambda}_{m}$ and $\boldsymbol{\lambda}_{h}$ are factor loadings (called "persistence parameters" by @mccaffreyModelsValueAddedModeling2004 and @jeonProfileLikelihoodApproachEstimating2012) specifying how the teacher effects for middle school and high school impact the self esteem measurement. Since students attend high school after middle school, the measurements of self esteem in middle school are assumed not to be affected by high school, and hence the first two elements of $\boldsymbol{\lambda}_{h}$ are set to zero. The first nonzero element is set to zero for identifiability, so we have $\boldsymbol{\lambda}_{h} = (0, 0, 1, \lambda_{h4})^{T}$. Conversely, we allow for middle school to have an effect of measurements in high school, so $\boldsymbol{\lambda}_{m} = (1, \lambda_{m2}, \lambda_{m3}, \lambda_{m4})^{T}$, with the first element set to zero for identifiability. The residuals are assumed normally distributed, $\epsilon_{tsmh} \sim N(0, \phi)$.
+where $\mathbf{d}_{t} = (d_{t1},d_{t2},d_{t3},d_{t4})^{T}$ is a vector whose $t$th element equals one and all other elements equal zero. $\beta_{0}$ is an intercept, and $\beta_{2}$, $\beta_{3}$, and $\beta_{4}$ are the effects of timepoints 2, 3, and 4. $\eta_{m}$ and $\eta_{h}$ are the "teacher effects" of middle school $m$ and high school $s$, respectively, $\eta_{s}$ is the latent level for student $s$, and $\epsilon_{tsmh}$ is a residual term. $\pmb{\lambda}_{m}$ and $\pmb{\lambda}_{h}$ are factor loadings (called "persistence parameters" by @mccaffreyModelsValueAddedModeling2004 and @jeonProfileLikelihoodApproachEstimating2012) specifying how the teacher effects for middle school and high school impact the self esteem measurement. Since students attend high school after middle school, the measurements of self esteem in middle school are assumed not to be affected by high school, and hence the first two elements of $\pmb{\lambda}_{h}$ are set to zero. The first nonzero element is set to zero for identifiability, so we have $\pmb{\lambda}_{h} = (0, 0, 1, \lambda_{h4})^{T}$. Conversely, we allow for middle school to have an effect of measurements in high school, so $\pmb{\lambda}_{m} = (1, \lambda_{m2}, \lambda_{m3}, \lambda_{m4})^{T}$, with the first element set to zero for identifiability. The residuals are assumed normally distributed, $\epsilon_{tsmh} \sim N(0, \phi)$.
 
 Written out for each of the four timepoints, the model becomes
 
@@ -97,7 +97,7 @@ $$
 
 where $N_{3}(a, b)$ denotes a trivariate normal distribution with mean $a$ and covariance $b$.
 
-In order to fit the model with galamm, we use syntax similar to PLmixed, and start by defining the loading matrix. The first column contains $\boldsymbol{\lambda}_{m}$ and the second column contains $\boldsymbol{\lambda}_{h}$. Numerical values in this matrix means that the entry is fixed to the given value, whereas `NA` means that the value is unknown, and should be estimated.
+In order to fit the model with galamm, we use syntax similar to PLmixed, and start by defining the loading matrix. The first column contains $\pmb{\lambda}_{m}$ and the second column contains $\pmb{\lambda}_{h}$. Numerical values in this matrix means that the entry is fixed to the given value, whereas `NA` means that the value is unknown, and should be estimated.
 
 
 
@@ -227,7 +227,7 @@ plot(mod, abline = c(0, 0))
 
 ![Diagnostic plot for linear mixed model with factor structures.](lmm_factor_diagnostic_plot-1.png)
 
-We can also compare the estimated model to a model with constrained factor loadings. In particular, we could assume that the teacher effect in middle school has no effect on self esteem measured during high school, by setting the last two elements of $\boldsymbol{\lambda}_{m}$ to zero. We would then have the following loading matrix.
+We can also compare the estimated model to a model with constrained factor loadings. In particular, we could assume that the teacher effect in middle school has no effect on self esteem measured during high school, by setting the last two elements of $\pmb{\lambda}_{m}$ to zero. We would then have the following loading matrix.
 
 
 ``` r
@@ -414,7 +414,7 @@ y_{12tsc} \\
 \eta_{6s}^{(s)} \\
 \eta_{7c}^{(c)} \\
 \end{pmatrix} +
-\boldsymbol{\epsilon}_{tsc}
+\pmb{\epsilon}_{tsc}
 $$
 
 In brief, $\eta_{1t}^{(t)}$ and $\eta_{2t}^{(t)}$ are the teacher effects, $\eta_{3s}^{(s)}$ and $\eta_{4s}^{(s)}$ are teacher's perception of the students on the trait, $\eta_{5s}^{(s)}$ and $\eta_{6s}^{(s)}$ are the students' perception of themselves on the trait, and $\eta_{7c}^{(c)}$ is the classroom effect. The factor loadings are the "regression coefficients" for regressing the observed items onto these latent traits. The subscripts $t$, $s$, and $c$ indicate teacher, student, and class, respectively.
@@ -450,7 +450,7 @@ $$
 \zeta_{1t}^{(t)} \\
 \zeta_{2t}^{(t)} \\
 \end{pmatrix}
-\sim N_{2}(\mathbf{0}, \boldsymbol{\Psi}^{(t)}),
+\sim N_{2}(\mathbf{0}, \pmb{\Psi}^{(t)}),
 $$
 
 $$
@@ -460,7 +460,7 @@ $$
 \zeta_{5s}^{(s)} \\
 \zeta_{6s}^{(s)} \\
 \end{pmatrix}
-\sim N_{4}(\mathbf{0}, \boldsymbol{\Psi}^{(s)}),
+\sim N_{4}(\mathbf{0}, \pmb{\Psi}^{(s)}),
 $$
 
 $$

--- a/vignettes/lmm_heteroscedastic.Rmd
+++ b/vignettes/lmm_heteroscedastic.Rmd
@@ -22,7 +22,7 @@ library(galamm)
 At the moment, galamm supports group-wise heteroscedasticity in Gaussian response models. Referring to the model formulation outlined in the [introductory vignette](https://docs.ropensci.org/galamm/articles/galamm.html), the response model and nonlinear predictor can be easily combined in this particular case, to give
 
 $$
-y_{i} = \sum_{s=1}^{S} f_{s}\left(\mathbf{x}_{i}\right) + \sum_{l=2}^{L}\sum_{m=1}^{M_{l}} \eta_{m}^{(l)} \mathbf{z}^{(l)}_{im}{}^{'}\boldsymbol{\lambda}_{m}^{(l)} + \epsilon_{g(i)},
+y_{i} = \sum_{s=1}^{S} f_{s}\left(\mathbf{x}_{i}\right) + \sum_{l=2}^{L}\sum_{m=1}^{M_{l}} \eta_{m}^{(l)} \mathbf{z}^{(l)}_{im}{}^{'}\pmb{\lambda}_{m}^{(l)} + \epsilon_{g(i)},
 $$
 
 where subscript $i$ refers to the $i$th elementary unit of observation, i.e., the $i$th row in the dataframe. $g(i)$ refers to the group to which the $i$th observation belongs, with each grouping having a separately estimated residual variance, $\epsilon_{g} \sim N(0, \sigma_{g}^{2})$.

--- a/vignettes/mixed_response.Rmd
+++ b/vignettes/mixed_response.Rmd
@@ -48,9 +48,9 @@ for the $i$th observation of the $j$ subject. Although we don't show this with a
 
 Next, the nonlinear predictor is given by
 
-$$\nu_{ij} = \beta_{0} + x_{ij}\beta_{1} + \mathbf{z}_{ij}^{T}\boldsymbol{\lambda} \eta$$
+$$\nu_{ij} = \beta_{0} + x_{ij}\beta_{1} + \mathbf{z}_{ij}^{T}\pmb{\lambda} \eta$$
 
-where $x_{ij}$ is an explanatory and $\mathbf{z}_{ij}$ is a dummy vector of length 2 with exactly one element equal to one and one element equal to zero. When `itemgroup = "a"`, $\mathbf{z} = (1, 0)^{T}$ and when `itemgroup = "b"`, $\mathbf{z} = (0, 1)^{T}$. The parameter $\boldsymbol{\lambda} = (1, \lambda)^{T}$ is a vector of factor loadings, whose first element equals zero for identifiability. $\eta$ is a latent variable, in this case representing an underlying trait "causing" the observed responses.
+where $x_{ij}$ is an explanatory and $\mathbf{z}_{ij}$ is a dummy vector of length 2 with exactly one element equal to one and one element equal to zero. When `itemgroup = "a"`, $\mathbf{z} = (1, 0)^{T}$ and when `itemgroup = "b"`, $\mathbf{z} = (0, 1)^{T}$. The parameter $\pmb{\lambda} = (1, \lambda)^{T}$ is a vector of factor loadings, whose first element equals zero for identifiability. $\eta$ is a latent variable, in this case representing an underlying trait "causing" the observed responses.
 
 The structural model is simply
 
@@ -60,7 +60,7 @@ $$
 
 where $N(0, \psi)$ denotes a normal distribution with mean 0 and variance $\psi$.
 
-We define the loading matrix as follows, where the value `1` indicates that the first element $\boldsymbol{\lambda}$ is fixed, and the value `NA` indicates that its second element is unknown, and to be estimated.
+We define the loading matrix as follows, where the value `1` indicates that the first element $\pmb{\lambda}$ is fixed, and the value `NA` indicates that its second element is unknown, and to be estimated.
 
 
 ``` r
@@ -235,7 +235,7 @@ diet[diet$id %in% c(219, 220, 221), ]
 
 Our first goal is to model the effect of fiber intake on risk of heart disease. Since this variable is very likely to be subject to measurement error, it is well known that simply averaging the two measurements, where available, and using the single measurement otherwise, will lead to bias and lack of power [@carrollMeasurementErrorNonlinear2006]. Instead, we let $\eta_{j}$ denote the true (latent) fiber intake of person $j$, and define the structural model
 
-$$\eta_{j} = \mathbf{x}_{ij}'\boldsymbol{\gamma} + \zeta_{j}.$$
+$$\eta_{j} = \mathbf{x}_{ij}'\pmb{\gamma} + \zeta_{j}.$$
 
 where $\mathbf{x}_{ij}$ is a vector of covariates age, bus, and their interaction, as well as a constant term for defining the intercept. The R formula for setting up the model matrix would be `model.matrix(~ age * bus, data = diet)`. The term $\zeta_{j}$ is a normally distributed disturbance, $\zeta_{j} \sim N(0, \psi)$.
 
@@ -249,16 +249,16 @@ $$y_{ij} = d_{2ij} \beta_{0} + \eta_{j} + \epsilon_{ij}, \qquad \epsilon_{ij} = 
 
 Next, for the rows corresponding to coronary heart disease measurement, we assume a binomial model with a logit link function, i.e., logistic regression. This model is given by
 
-$$\text{logit}[P(y_{ij}=1 | \eta_{j})] = \mathbf{x}_{ij}'\boldsymbol{\beta} + \lambda \eta_{j},$$
+$$\text{logit}[P(y_{ij}=1 | \eta_{j})] = \mathbf{x}_{ij}'\pmb{\beta} + \lambda \eta_{j},$$
 
-where $\mathbf{x}_{ij}$ is the same as before, but where $\boldsymbol{\beta}$ now represents the direct effect of age and bus on the probability of coronary heart disease. The factor loading $\lambda$ is the regression coefficient for latent fiber intake on the risk of coronary heart disease.
+where $\mathbf{x}_{ij}$ is the same as before, but where $\pmb{\beta}$ now represents the direct effect of age and bus on the probability of coronary heart disease. The factor loading $\lambda$ is the regression coefficient for latent fiber intake on the risk of coronary heart disease.
 
 
 ### Nonlinear Predictor
 
 Stacking the three responses, which are fiber intake at times 1 and 2, and coronary heart disease, we can define the joint model as a GLLAMM with nonlinear predictor
 
-$$\nu_{ij} = d_{2ij} \beta_{0} + d_{3ij} \mathbf{x}_{j}'\boldsymbol{\beta} + \mathbf{x}_{j}'\boldsymbol{\gamma}\left[(d_{1i} + d_{2i}) + \lambda d_{3i}\right] + \zeta_{j} \left[(d_{1i} + d_{2i}) + \lambda d_{3i}\right],$$
+$$\nu_{ij} = d_{2ij} \beta_{0} + d_{3ij} \mathbf{x}_{j}'\pmb{\beta} + \mathbf{x}_{j}'\pmb{\gamma}\left[(d_{1i} + d_{2i}) + \lambda d_{3i}\right] + \zeta_{j} \left[(d_{1i} + d_{2i}) + \lambda d_{3i}\right],$$
 
 where $d_{1i}$ is a dummy variable for fiber measurements at timepoint 1 and $d_{3i}$ is an indicator for coronary heart disease.
 
@@ -313,7 +313,7 @@ formula <- y ~ 0 + chd + (age * bus):chd + fiber +
   (age * bus):fiber + fiber2 + (0 + loading | id)
 ```
 
-The initial zero specifies that we don't want R to insert an intercept term. Next, `chd + (age * bus) : chd` applies to "chd" rows only, and corresponds to $\mathbf{x}_{ij}^{T} \boldsymbol{\beta}$ in the disease model. The part `fiber + (age * bus) : fiber` corresponds to the term $\mathbf{x}_{ij}^{T}\boldsymbol{\gamma}$ in the disease model, and `fiber2` corresponds to the drift term $d_{2ij}\beta_{0}$.
+The initial zero specifies that we don't want R to insert an intercept term. Next, `chd + (age * bus) : chd` applies to "chd" rows only, and corresponds to $\mathbf{x}_{ij}^{T} \pmb{\beta}$ in the disease model. The part `fiber + (age * bus) : fiber` corresponds to the term $\mathbf{x}_{ij}^{T}\pmb{\gamma}$ in the disease model, and `fiber2` corresponds to the drift term $d_{2ij}\beta_{0}$.
 
 We can inspect the model implied by the formula by using the `nobars` function from [lme4](https://cran.r-project.org/package=lme4) [@batesFittingLinearMixedEffects2015] to remove the random effects, and then `model.matrix`. It looks correctly set up.
 


### PR DESCRIPTION
Hi,

Thanks for the great package.

Reading the documentation, I noticed that certain latex were broken

E.g., https://docs.ropensci.org/galamm/articles/lmm_factor.html

<img width="1263" height="142" alt="image" src="https://github.com/user-attachments/assets/ef6183c6-fd84-42e4-a6f6-c84e81aea6b4" />


So I  did a fork and PR, where I manually used Ctrl + F and replace to change \boldsymbol to \pmb, as suggested by Claude Opus 5. I used the IDE to make the replacements and not an LLM, LLM for diagnosis.

I also tested the vignettes locally using pkgdown to make sure that things are fixed

<img width="705" height="94" alt="image" src="https://github.com/user-attachments/assets/405452ce-8dfa-4112-9b8c-a48a3e6d28af" />
